### PR TITLE
Listeners are now properly registered.

### DIFF
--- a/src/main/kotlin/com/learnspigot/bot/LearnSpigotBot.kt
+++ b/src/main/kotlin/com/learnspigot/bot/LearnSpigotBot.kt
@@ -85,6 +85,7 @@ class LearnSpigotBot {
         forumManager = ForumManager(bot, datastore, leaderboardManager)
         verificationManager = VerificationManager(datastore)
         registerCommands()
+        registerListeners()
         bot.listener<MessageReceivedEvent> {
             if(it.member == null) return@listener
             val profile: UserProfile = datastore.findUserProfile(it.member!!.id)


### PR DESCRIPTION
`registerListeners()` was missing during initialization, this adds that and thus makes the listeners actually functional 