### PR TITLE
List users that were given reputation.

### DIFF
--- a/src/main/kotlin/com/learnspigot/bot/manager/ForumManager.kt
+++ b/src/main/kotlin/com/learnspigot/bot/manager/ForumManager.kt
@@ -23,6 +23,7 @@ import net.dv8tion.jda.api.interactions.components.selections.SelectOption
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.*
+import java.util.stream.Collectors
 import kotlin.time.Duration.Companion.seconds
 
 class ForumManager(private val bot: JDA, private val datastore: Datastore, private val leaderboardManager: LeaderboardManager) {
@@ -126,6 +127,8 @@ class ForumManager(private val bot: JDA, private val datastore: Datastore, priva
                 channel.sendMessageEmbeds(Embed {
                     description = "${event.member!!.asMention} has closed the thread"
                     color = LearnSpigotBot.EMBED_COLOR
+                    if (selectedContributors.isNotEmpty()) field("Gave reputation to:", selectedContributors.stream().map { contributor -> "- ${bot.getUserById(contributor)!!.asMention}" }.collect(
+                        Collectors.joining("\n")))
                 }).complete()
                 channel.manager.setArchived(true).setLocked(true).queue()
                 bot.removeEventListener(this)

--- a/src/main/kotlin/com/learnspigot/bot/manager/ForumManager.kt
+++ b/src/main/kotlin/com/learnspigot/bot/manager/ForumManager.kt
@@ -127,7 +127,7 @@ class ForumManager(private val bot: JDA, private val datastore: Datastore, priva
                 channel.sendMessageEmbeds(Embed {
                     description = "${event.member!!.asMention} has closed the thread"
                     color = LearnSpigotBot.EMBED_COLOR
-                    if (selectedContributors.isNotEmpty()) field("Gave reputation to:", selectedContributors.stream().map { contributor -> "- ${bot.getUserById(contributor)!!.asMention}" }.collect(
+                    if (selectedContributors.isNotEmpty()) field("Gave reputation to selected contributor${if (selectedContributors.size >= 2) "s" else ""}.", selectedContributors.stream().map { contributor -> "- ${bot.getUserById(contributor)!!.asMention}" }.collect(
                         Collectors.joining("\n")))
                 }).complete()
                 channel.manager.setArchived(true).setLocked(true).queue()


### PR DESCRIPTION
Shows the users that were given reputation upon closing thread. Since this data is already public with `/rep <user>` this should be perfectly fine. This list does not ping users and only is meant for the people who helped out to see who was rep'ed without having to run the command.

![image](https://user-images.githubusercontent.com/29359616/208777622-fca92d1c-1b73-489b-b21f-df74e369888d.png)

If no one was given rep it doesn't show the field.
![image](https://user-images.githubusercontent.com/29359616/208777897-7603a15b-53ba-4053-9f29-a6348c855c6c.png)

