### PR TITLE
Fuzzy search for lectures and quizes.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,8 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.1")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.1")
     testImplementation(kotlin("test"))
+
+    implementation("me.xdrop:fuzzywuzzy:1.4.0")
 }
 
 application {

--- a/src/main/kotlin/com/learnspigot/bot/command/LectureCommand.kt
+++ b/src/main/kotlin/com/learnspigot/bot/command/LectureCommand.kt
@@ -19,7 +19,6 @@ class LectureCommand(private val guild: Guild, private val bot: JDA, private val
             bot.onCommand("lecture") {
                 it.deferReply().queue()
                 val lectures = searcher.findLecture(it.getOption("query")!!.asString, amount = 4).toMutableList()
-
                 it.hook.editOriginalEmbeds(Embed {
                     val topLecture = lectures[0]
                     title = topLecture.title

--- a/src/main/kotlin/com/learnspigot/bot/entity/CourseContent.kt
+++ b/src/main/kotlin/com/learnspigot/bot/entity/CourseContent.kt
@@ -1,0 +1,5 @@
+package com.learnspigot.bot.entity
+
+open class CourseContent(
+    open val title: String,
+)

--- a/src/main/kotlin/com/learnspigot/bot/entity/Lecture.kt
+++ b/src/main/kotlin/com/learnspigot/bot/entity/Lecture.kt
@@ -1,9 +1,9 @@
 package com.learnspigot.bot.entity
 
-data class Lecture(
+class Lecture(
     val id: String,
-    val title: String,
+    override val title: String,
     val description: String,
-) {
+) : CourseContent(title) {
     val url = "https://www.udemy.com/course/develop-minecraft-plugins-java-programming/learn/lecture/$id"
 }

--- a/src/main/kotlin/com/learnspigot/bot/entity/Quiz.kt
+++ b/src/main/kotlin/com/learnspigot/bot/entity/Quiz.kt
@@ -1,9 +1,9 @@
 package com.learnspigot.bot.entity
 
-data class Quiz(
+class Quiz(
     val id: String,
-    val title: String,
+    override val title: String,
     val passPercentage: Int,
-) {
+) : CourseContent(title) {
     val url = "https://www.udemy.com/course/develop-minecraft-plugins-java-programming/learn/quiz/$id"
 }


### PR DESCRIPTION
Improve /lecture command using [fuzzywuzzy](https://github.com/xdrop/fuzzywuzzy). No problems so far and misspellings work extremely well. Also works with /quiz. 

Examples:
![image](https://user-images.githubusercontent.com/29359616/208964993-1d6e7b38-22e3-4d3e-ab20-ee95a9dc7773.png)
![image](https://user-images.githubusercontent.com/29359616/208965042-38eeb7eb-3c4e-4302-91c4-fa76703318ad.png)
![image](https://user-images.githubusercontent.com/29359616/208965112-8c41ec57-ca4a-4ca3-858e-58001b879434.png)
![image](https://user-images.githubusercontent.com/29359616/208965164-eef2eecc-f5a1-4b42-b2d0-85566cad153a.png)
