### PR TITLE
Show error on thread close if person is not the author.

### DIFF
--- a/src/main/kotlin/com/learnspigot/bot/manager/ForumManager.kt
+++ b/src/main/kotlin/com/learnspigot/bot/manager/ForumManager.kt
@@ -2,6 +2,7 @@ package com.learnspigot.bot.manager
 
 import com.learnspigot.bot.LearnSpigotBot
 import com.learnspigot.bot.LearnSpigotBot.Companion.findUserProfile
+import com.learnspigot.bot.LearnSpigotBot.Companion.replyEmbed
 import com.learnspigot.bot.entity.ReputationPoint
 import com.learnspigot.bot.entity.UserProfile
 import dev.minn.jda.ktx.events.listener
@@ -146,6 +147,11 @@ class ForumManager(private val bot: JDA, private val datastore: Datastore, priva
                 }).complete()
                 channel.manager.setArchived(true).setLocked(true).queue()
                 bot.removeEventListener(this)
+            } else {
+                event.replyEmbed({
+                    description = "You cannot close the thread as you are not the author!"
+                    color = LearnSpigotBot.EMBED_COLOR
+                }, ephemeral = true).queue()
             }
         }
     }


### PR DESCRIPTION
Shows a helpful message if someone tries to close a thread that they don't own, *and* they don't have normal manage threads permission.

![image](https://user-images.githubusercontent.com/29359616/209456897-6c80c44c-8c22-4099-b389-49e2f1e4ad0c.png)
