### PR TITLE
Fix for broken modal menu when giving rep via context / apps button

### DIFF
--- a/src/main/kotlin/com/learnspigot/bot/command/ReputationCommand.kt
+++ b/src/main/kotlin/com/learnspigot/bot/command/ReputationCommand.kt
@@ -216,15 +216,16 @@ class ReputationCommand(private val guild: Guild, private val bot: JDA, private 
                 it.deferReply(true).queue()
                 val profile: UserProfile = datastore.findUserProfile(it.modalId.split("-")[2])
 
+                val amount: Int = it.getValue("amount")?.asString?.toInt() ?: 1
                 val channel: TextChannel? = if((it.getValue("channel")?.asString ?: "") == "") null else it.guild?.getTextChannelById(it.getValue("channel")!!.asString)
                 val user: Member? = if((it.getValue("member")?.asString ?: "") == "") null else it.guild?.getMemberById(it.getValue("member")!!.asString)
                 val rep = ReputationPoint(System.currentTimeMillis(), channel?.id, user?.id)
-                profile.addHelpRep(rep, leaderboardManager, it.guild!!)
+                profile.addHelpRep(rep, leaderboardManager, it.guild!!, amount)
                 datastore.save(profile)
 
                 it.editEmbed({
                     title = "Reputation added"
-                    description = "You added 1 reputation point to <@${profile.id}>"
+                    description = "You added $amount reputation point to <@${profile.id}>"
                     field("Time", "<t:${rep.epochTimestamp.milliseconds.inWholeSeconds}:f>", false)
                     if(rep.fromMemberId != null) {
                         field("From", "<@${rep.fromMemberId}>", false)

--- a/src/main/kotlin/com/learnspigot/bot/entity/UserProfile.kt
+++ b/src/main/kotlin/com/learnspigot/bot/entity/UserProfile.kt
@@ -20,13 +20,18 @@ data class UserProfile(
     val messageHistory: MutableList<SerializedMessage> = mutableListOf(),
     var reputationPing : Boolean = false
 ) {
-    fun addHelpRep(channelSource: MessageChannel?, memberSource: Member?, leaderboardManager: LeaderboardManager, guild: Guild) {
-        addHelpRep(ReputationPoint(System.currentTimeMillis(), memberSource?.id, channelSource?.id), leaderboardManager, guild)
+
+    fun addHelpRep(channelSource: MessageChannel?, memberSource: Member?, leaderboardManager: LeaderboardManager, guild: Guild, amount: Int = 1) {
+        repeat(amount) {
+            addHelpRep(ReputationPoint(System.currentTimeMillis(), memberSource?.id, channelSource?.id), leaderboardManager, guild, amount)
+        }
     }
 
-    fun addHelpRep(point: ReputationPoint, leaderboardManager: LeaderboardManager, guild: Guild) {
-        reputation.add(point)
-        acknowledgeHelpRep(point, leaderboardManager, guild)
+    fun addHelpRep(point: ReputationPoint, leaderboardManager: LeaderboardManager, guild: Guild, amount: Int = 1) {
+        repeat(amount) {
+            reputation.add(point)
+            acknowledgeHelpRep(point, leaderboardManager, guild)
+        }
     }
 
     fun addKnowledgeBaseRep(leaderboardManager: LeaderboardManager, guild: Guild, type: KnowledgeBaseType, count: Int) {


### PR DESCRIPTION
The amount field in the modal now works. 
The functions within userprofile is updated accordingly to allow for easy processing of multiple reps at a time.

This closes #117 