### PR TITLE
Added the ability to undo action taken on a verification request.

### DIFF
--- a/src/main/kotlin/com/learnspigot/bot/verification/VerificationListener.kt
+++ b/src/main/kotlin/com/learnspigot/bot/verification/VerificationListener.kt
@@ -139,6 +139,35 @@ class VerificationListener : ListenerAdapter() {
                         ).queue(null, ErrorHandler().handle(ErrorResponse.CANNOT_SEND_TO_USER) {})
                     }
                 }
+                "undo" -> {
+                    guild.removeRoleFromMember(member, guild.getRoleById(Environment.get("STUDENT_ROLE_ID"))!!).queue()
+                    e.message.editMessageEmbeds(
+                        embed()
+                            .setTitle("Profile Verification")
+                            .setDescription("Please verify that " + member.asMention + " owns the course." +
+                                    "\n\nPrevious action reverted by: ${e.member!!.asMention}")
+                            .addField("Udemy Link", url, false)
+                            .build())
+                        .setActionRow(
+                            Button.success("v|a|" + url + "|" + member.id, "Approve"),
+                            Button.danger("v|wl|" + url + "|" + member.id, "Wrong Link"),
+                            Button.danger("v|ch|" + url + "|" + member.id, "Courses Hidden"),
+                            Button.danger("v|no|" + url + "|" + member.id, "Not Owned"))
+                        .queue()
+
+                    e.interaction.deferEdit().queue()
+
+                    member.user.openPrivateChannel().complete().let {
+                        it.sendMessageEmbeds(
+                            embed()
+                                .setTitle("Profile Verification")
+                                .setDescription("Please disregard the previous message regarding your verification status - a staff member has reverted the action. Please remain patient while waiting for a corrected decision.\n\n" +
+                                        "If you were previously verified and granted the student role, the role has been removed pending the corrected decision from staff.")
+                                .build()
+                        ).queue(null, ErrorHandler().handle(ErrorResponse.CANNOT_SEND_TO_USER) {})
+                    }
+                    return
+                }
             }
 
             e.message.editMessageEmbeds(
@@ -147,10 +176,7 @@ class VerificationListener : ListenerAdapter() {
                     .setDescription(e.member!!.asMention + " " + description.replace(":mention:", member.asMention) + ".")
                     .build())
                 .setActionRow(
-                    Button.success("ignore1", "Approve").asDisabled(),
-                    Button.danger("ignore2", "Wrong Link").asDisabled(),
-                    Button.danger("ignore3", "Courses Hidden").asDisabled(),
-                    Button.danger("ignore4", "Not Owned").asDisabled())
+                    Button.danger("v|undo|" + url + "|" + member.id, "Undo"))
                 .queue()
 
             e.interaction.deferEdit().queue()


### PR DESCRIPTION
With the current design, the bot will allow anyone with access to make a decision on the request to also undo it.
The embed will revert back to how it looked before action was taken and also include a new line with the name of the person who clicked the undo button to make sure it's clear to everyone who it was in case clarification is needed.

I have thought about the need to make the option temporary, but not sure if it's needed.

This change would also make the undo button the only one present on the embed after action has been taken, as opposed to the greyed-out buttons now.