### PR TITLE
Fix /countingstats showing top 5 incorrectly

### DIFF
--- a/src/main/kotlin/com/learnspigot/bot/Bot.kt
+++ b/src/main/kotlin/com/learnspigot/bot/Bot.kt
@@ -24,6 +24,7 @@ import net.dv8tion.jda.api.utils.MemberCachePolicy
 
 class Bot {
     private val profileRegistry = ProfileRegistry()
+    private val countingRegistry = CountingRegistry(this)
 
     init {
         jda = JDABuilder.createDefault(Environment.get("BOT_TOKEN"))
@@ -45,6 +46,8 @@ class Bot {
         val guild = jda.getGuildById(Environment.get("GUILD_ID"))!!
         VerificationMessage(guild)
         LeaderboardMessage(profileRegistry)
+
+        countingRegistry.initLeaderboard(profileRegistry)
 
         guild.updateCommands().addCommands(
             Commands.context(Command.Type.MESSAGE, "Set vote").setDefaultPermissions(DefaultMemberPermissions.enabledFor(PermissionRole.STUDENT)),
@@ -89,7 +92,7 @@ class Bot {
         return HelpPostRegistry()
     }
 
-    @Instantiate fun countingRegistry(): CountingRegistry = CountingRegistry(profileRegistry)
+    @Instantiate fun countingRegistry(): CountingRegistry = countingRegistry
 
     companion object {
         lateinit var jda: JDA

--- a/src/main/kotlin/com/learnspigot/bot/counting/CountingCommand.kt
+++ b/src/main/kotlin/com/learnspigot/bot/counting/CountingCommand.kt
@@ -24,7 +24,7 @@ class CountingCommand {
                 embed()
                     .setTitle("Server counting statistics")
                     .setDescription("""
-                        - Current Count: ${countingRegistry.currentCount}
+                        - Last Count: ${countingRegistry.currentCount}
                         - Total Counts: ${countingRegistry.serverTotalCounts}
                         - Highest Count: ${countingRegistry.topServerCount}
                     """.trimIndent())

--- a/src/main/kotlin/com/learnspigot/bot/profile/ProfileRegistry.kt
+++ b/src/main/kotlin/com/learnspigot/bot/profile/ProfileRegistry.kt
@@ -37,9 +37,9 @@ class ProfileRegistry {
                 document.getInteger("totalCounts", 0),
                 document.getInteger("countingFuckUps", 0)
             ).let {
-                    profileCache[it.id] = it
-                    if (it.udemyProfileUrl != null)
-                        urlProfiles[it.udemyProfileUrl!!] = it
+                profileCache[it.id] = it
+                if (it.udemyProfileUrl != null)
+                    urlProfiles[it.udemyProfileUrl!!] = it
             }
         }
     }


### PR DESCRIPTION
Patches:
- Showing less than 5 people in list
- Showing people in the incorrect order,
- Showing the same person multiple times (if they counted while the bot was initialising)
- Leaderboard trailing one count behind

![image](https://github.com/flytegg/ls-discord-bot/assets/72254337/5c8da075-dce6-49ea-8fde-329d5ce574a3)
![image](https://github.com/flytegg/ls-discord-bot/assets/72254337/1d7fe4f9-300b-4855-9fd7-314cdc908d57)

Tested in test server with the small dataset, hopefully covered all bases.