### PR TITLE
fix(counting stats)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     implementation("gg.flyte:neptune:2.4")
     implementation("org.mongodb:mongodb-driver-sync:4.9.0")
     implementation("io.github.cdimascio:dotenv-kotlin:6.4.1")
-    implementation("com.github.mlgpenguin:MathEvaluator:1.2.8")
+    implementation("com.github.mlgpenguin:MathEvaluator:2.0.0")
 }
 
 application {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     implementation("gg.flyte:neptune:2.4")
     implementation("org.mongodb:mongodb-driver-sync:4.9.0")
     implementation("io.github.cdimascio:dotenv-kotlin:6.4.1")
-    implementation("com.github.mlgpenguin:MathEvaluator:2.0.0")
+    implementation("com.github.mlgpenguin:MathEvaluator:2.0.2")
 }
 
 application {

--- a/src/main/kotlin/com/learnspigot/bot/Bot.kt
+++ b/src/main/kotlin/com/learnspigot/bot/Bot.kt
@@ -47,8 +47,6 @@ class Bot {
         VerificationMessage(guild)
         LeaderboardMessage(profileRegistry)
 
-        countingRegistry.initLeaderboard(profileRegistry)
-
         guild.updateCommands().addCommands(
             Commands.context(Command.Type.MESSAGE, "Set vote").setDefaultPermissions(DefaultMemberPermissions.enabledFor(PermissionRole.STUDENT)),
             Commands.context(Command.Type.MESSAGE, "Set Tutorial vote").setDefaultPermissions(DefaultMemberPermissions.enabledFor(PermissionRole.EXPERT)),

--- a/src/main/kotlin/com/learnspigot/bot/counting/CountingCommand.kt
+++ b/src/main/kotlin/com/learnspigot/bot/counting/CountingCommand.kt
@@ -19,7 +19,7 @@ class CountingCommand {
         event: SlashCommandInteractionEvent,
         @Description("User's stats to view") @Optional user: User?
     ) {
-        if (user == null) { // Server stats
+        if (user == null) { // Server Stats
             event.replyEmbeds(
                 embed()
                     .setTitle("Server counting statistics")
@@ -30,10 +30,8 @@ class CountingCommand {
                     """.trimIndent())
                     .addField(
                         "Top 5 counters",
-                        countingRegistry.leaderboard.take(5).joinToString("") {
-                            val profile = profileRegistry.findById(it)!!
-                            if (profile.tag == null || profile.totalCounts == 0) return@joinToString ""
-                            "\n- ${profile.tag}: ${profile.totalCounts}"
+                        countingRegistry.getTop5().joinToString("") { profile ->
+                            "\n- <@${profile.id}>: ${profile.totalCounts}"
                         },
                         false
                     )

--- a/src/main/kotlin/com/learnspigot/bot/vote/VoteListener.kt
+++ b/src/main/kotlin/com/learnspigot/bot/vote/VoteListener.kt
@@ -1,13 +1,11 @@
 package com.learnspigot.bot.vote
 
-import com.google.common.cache.Cache
 import com.google.common.cache.CacheBuilder
 import com.learnspigot.bot.Environment
 import com.learnspigot.bot.Server
 import net.dv8tion.jda.api.entities.emoji.Emoji
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
-import java.util.*
 import java.util.concurrent.TimeUnit
 
 class VoteListener : ListenerAdapter() {
@@ -26,6 +24,9 @@ class VoteListener : ListenerAdapter() {
 
         when (event.name) {
             "Set vote" -> event.run {
+                if (event.channel!!.id == Server.countingChannel.id) // Stop fake counting bullshit
+                    return event.reply("You cannot use that in this channel.").setEphemeral(true).queue()
+
                 val member = event.member!!
                 val roles = member.roles
                 if (cooldown.asMap().containsKey(member.id) &&


### PR DESCRIPTION
Live sort leaderboard on request instead of relying on queue-sort thus fixing the leaderboard

- Approx. runtime per sort < 10ms

closes #248 