### PR TITLE
Fix the thread close timeout problem

### DIFF
--- a/src/main/kotlin/com/learnspigot/bot/help/CloseCommand.kt
+++ b/src/main/kotlin/com/learnspigot/bot/help/CloseCommand.kt
@@ -38,16 +38,19 @@ class CloseCommand {
             return
         }
 
+        event.deferReply().queue()
+
         val contributors: List<Member> =
-            channel.retrieveThreadMembers().complete().asSequence().filter { member: ThreadMember -> member.id != channel.ownerId }
+            channel.retrieveThreadMembers().complete().asSequence()
+                .filter { member: ThreadMember -> member.id != channel.ownerId }
                 .filter { member: ThreadMember -> !member.user.isBot }
-                .filter{ member: ThreadMember ->
+                .filter { member: ThreadMember ->
                     val messageHistory = channel.iterableHistory.complete()
                     messageHistory.any { it.author.id == member.id }}
                 .take(25).map { it.member }.toList()
 
         if (contributors.isEmpty()) {
-            event.replyEmbeds(
+            event.hook.sendMessageEmbeds(
                 embed().setTitle(event.member!!.effectiveName + " has closed the thread")
                     .setDescription("Listing no contributors.").build()
             ).complete()
@@ -58,8 +61,6 @@ class CloseCommand {
         channel.sendMessage(channel.owner!!.asMention).queue { message ->
             message.delete().queue()
         }
-
-        event.deferReply().queue()
 
         event.hook.sendMessageEmbeds(
             embed().setTitle("Who helped you solve your issue?").setDescription(

--- a/src/main/kotlin/com/learnspigot/bot/help/CloseCommand.kt
+++ b/src/main/kotlin/com/learnspigot/bot/help/CloseCommand.kt
@@ -42,8 +42,11 @@ class CloseCommand {
 
         val contributors: List<Member> =
             channel.retrieveThreadMembers().complete().asSequence()
+                // excludes the author of the channel
                 .filter { member: ThreadMember -> member.id != channel.ownerId }
+                // excludes bots
                 .filter { member: ThreadMember -> !member.user.isBot }
+                // excludes users that haven't sent a single message to this channel (i.e: users that clicked the 'follow post' button)
                 .filter { member: ThreadMember ->
                     val messageHistory = channel.iterableHistory.complete()
                     messageHistory.any { it.author.id == member.id }}


### PR DESCRIPTION
I moved `event.deferReply().queue()` to an earlier position in the code, since we're retrieving a list of thread members synchronously, and that should give us enough time to process and respond to the close message. 

I cannot 100% confirm that this is causing the issue, but adding `sleep(5000)` after retrieving the thread members reproduced the issue, so it's very likely that it is the culprit here. Additionally, from what I'm seeing, we are not running any other potentially costly operations aside from the aforementioned one, so 🤷🏻 