### PR TITLE
Knowledgebase post in help twice means twice in close, no more

### DIFF
--- a/src/main/kotlin/com/learnspigot/bot/help/CloseCommand.kt
+++ b/src/main/kotlin/com/learnspigot/bot/help/CloseCommand.kt
@@ -20,7 +20,7 @@ class CloseCommand {
     private lateinit var profileRegistry: ProfileRegistry
 
     companion object {
-        val knowledgebasePostsUsed = mutableMapOf<String, MutableList<String>>()
+        val knowledgebasePostsUsed = mutableMapOf<String, MutableSet<String>>()
     }
 
     @Command(

--- a/src/main/kotlin/com/learnspigot/bot/knowledgebase/KnowledgebaseCommand.kt
+++ b/src/main/kotlin/com/learnspigot/bot/knowledgebase/KnowledgebaseCommand.kt
@@ -41,7 +41,7 @@ class KnowledgebaseCommand {
                 .build()
         ).queue()
 
-        CloseCommand.knowledgebasePostsUsed.getOrPut(event.channel.id) { mutableListOf() }.add(topPost.id)
+        CloseCommand.knowledgebasePostsUsed.getOrPut(event.channel.id) { mutableSetOf() }.add(topPost.id)
     }
 
 }


### PR DESCRIPTION
use set for no duplicates because there were duplicates