### PR TITLE
Counting Decimal Precision fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     implementation("gg.flyte:neptune:2.4")
     implementation("org.mongodb:mongodb-driver-sync:4.9.0")
     implementation("io.github.cdimascio:dotenv-kotlin:6.4.1")
-    implementation("com.github.mlgpenguin:MathEvaluator:2.0.2")
+    implementation("com.github.mlgpenguin:MathEvaluator:2.1.1")
 }
 
 application {


### PR DESCRIPTION
4.1-0.1 evaluated to 3 thanks to a lovely decimal precision error, as 0.1 cannot be stored as a double, but rather it is stored as it's closest binary fractional counterpart: 0.1000000000000000055511151231257827021181583404541015625. 
This is now fixed alongside several other decimal precision issues that I'd encountered.