### PR TITLE
Added check to see if the first message of a Help Post contains code.  Added missing lecture about Display Entities and fixed a verification issue.

### DIFF
--- a/src/main/kotlin/com/learnspigot/bot/counting/CountingInsults.kt
+++ b/src/main/kotlin/com/learnspigot/bot/counting/CountingInsults.kt
@@ -63,6 +63,7 @@ object CountingInsults {
         "I didn't realize we were playing a counting remix.",
         "Did you accidentally press the repeat button on your counting machine?",
         "I guess counting once just wasn't enough for you.",
+        "You can't count twice in a row!",
         "You're like a broken record, but with numbers.",
         "Are you trying to see if the numbers change their minds?",
         "Your counting is like déjà vu - I feel like I've heard it before.",

--- a/src/main/kotlin/com/learnspigot/bot/counting/CountingInsults.kt
+++ b/src/main/kotlin/com/learnspigot/bot/counting/CountingInsults.kt
@@ -63,7 +63,6 @@ object CountingInsults {
         "I didn't realize we were playing a counting remix.",
         "Did you accidentally press the repeat button on your counting machine?",
         "I guess counting once just wasn't enough for you.",
-        "You can't count twice in a row!",
         "You're like a broken record, but with numbers.",
         "Are you trying to see if the numbers change their minds?",
         "Your counting is like déjà vu - I feel like I've heard it before.",

--- a/src/main/kotlin/com/learnspigot/bot/help/HastebinListener.kt
+++ b/src/main/kotlin/com/learnspigot/bot/help/HastebinListener.kt
@@ -3,6 +3,7 @@ package com.learnspigot.bot.help
 import com.google.gson.Gson
 import com.google.gson.JsonObject
 import com.learnspigot.bot.Server
+import com.learnspigot.bot.util.PasteBins
 import com.learnspigot.bot.util.embed
 import net.dv8tion.jda.api.entities.channel.ChannelType
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
@@ -18,9 +19,9 @@ class HastebinListener : ListenerAdapter() {
     private val GSON = Gson()
 
     private val KNOWN_PASTEBINS = listOf(
-        "pastebin.com",
-        "paste.md-5.net",
-        "paste.helpch.at"
+        PasteBins.pb,
+        PasteBins.md5,
+        PasteBins.helpch
     )
 
     private val LS_PASTEBIN = "https://paste.learnspigot.com"

--- a/src/main/kotlin/com/learnspigot/bot/help/ThreadListener.kt
+++ b/src/main/kotlin/com/learnspigot/bot/help/ThreadListener.kt
@@ -11,11 +11,23 @@ class ThreadListener : ListenerAdapter() {
         if (event.channelType != ChannelType.GUILD_PUBLIC_THREAD) return
         if (event.channel.asThreadChannel().parentChannel.id != Server.helpChannel.id) return
 
+        val threadChannel = event.channel.asThreadChannel()
+
+        val parentMessage = threadChannel.retrieveParentMessage().complete()
+
+        val PASTEBINS = listOf(
+            "pastebin.com",
+            "paste.md-5.net",
+            "paste.helpch.at",
+            "paste.learnspigot.com"
+        )
+
         val closeId = event.guild!!.retrieveCommands().complete()
             .firstOrNull { it.name == "close" }
             ?.id
+        val containsPastebinLink = PASTEBINS.any { parentMessage?.contentRaw?.contains(it, ignoreCase = true) == true }
 
-        event.channel.asThreadChannel().sendMessageEmbeds(
+        threadChannel.sendMessageEmbeds(
             embed()
                 .setTitle("Thank you for creating a post!")
                 .setDescription("""
@@ -25,5 +37,19 @@ class ThreadListener : ListenerAdapter() {
                 """.trimIndent())
                 .build()
         ).queue()
+
+        if (!containsPastebinLink) {
+            threadChannel.sendMessageEmbeds(
+                embed()
+                    .setTitle("No Code Provided!")
+                    .setDescription(
+                        """
+                        We've noticed that you didn't send us any code, if that's voluntary, you can ignore this message!
+                        If not, feel free to send us the code with our pastebin: https://paste.learnspigot.com
+                    """.trimIndent()
+                    )
+                    .build()
+            ).queue()
+        }
     }
 }

--- a/src/main/kotlin/com/learnspigot/bot/help/ThreadListener.kt
+++ b/src/main/kotlin/com/learnspigot/bot/help/ThreadListener.kt
@@ -19,7 +19,8 @@ class ThreadListener : ListenerAdapter() {
             "pastebin.com",
             "paste.md-5.net",
             "paste.helpch.at",
-            "paste.learnspigot.com"
+            "paste.learnspigot.com",
+            "```"
         )
 
         val closeId = event.guild!!.retrieveCommands().complete()

--- a/src/main/kotlin/com/learnspigot/bot/help/ThreadListener.kt
+++ b/src/main/kotlin/com/learnspigot/bot/help/ThreadListener.kt
@@ -1,6 +1,7 @@
 package com.learnspigot.bot.help
 
 import com.learnspigot.bot.Server
+import com.learnspigot.bot.util.PasteBins
 import com.learnspigot.bot.util.embed
 import net.dv8tion.jda.api.entities.channel.ChannelType
 import net.dv8tion.jda.api.events.channel.ChannelCreateEvent
@@ -13,18 +14,18 @@ class ThreadListener : ListenerAdapter() {
 
         val parentMessage = event.channel.asThreadChannel().retrieveParentMessage().complete()
 
-        val PASTEBINS = listOf(
-            "pastebin.com",
-            "paste.md-5.net",
-            "paste.helpch.at",
-            "paste.learnspigot.com",
-            "```"
+        val KNOWN_PASTEBINS = listOf(
+            PasteBins.ls,
+            PasteBins.pb,
+            PasteBins.md5,
+            PasteBins.discord,
+            PasteBins.helpch
         )
 
         val closeId = event.guild!!.retrieveCommands().complete()
             .firstOrNull { it.name == "close" }
             ?.id
-        val containsPastebinLink = PASTEBINS.any { parentMessage?.contentRaw?.contains(it, ignoreCase = true) == true }
+        val containsPastebinLink = KNOWN_PASTEBINS.any { parentMessage?.contentRaw?.contains(it, ignoreCase = true) == true }
 
         event.channel.asThreadChannel().sendMessageEmbeds(
             embed()

--- a/src/main/kotlin/com/learnspigot/bot/help/ThreadListener.kt
+++ b/src/main/kotlin/com/learnspigot/bot/help/ThreadListener.kt
@@ -40,7 +40,6 @@ class ThreadListener : ListenerAdapter() {
             ${if (!containsPastebinLink) """
             We've noticed that you didn't send us any code, if that's voluntary, you can ignore this message!
             If not, feel free to send us the code with our pastebin: https://paste.learnspigot.com""" else ""}
-            
             If you fixed your problem, please run ${if (closeId == null) "/close" else "</close:$closeId>"}.
             """.trimIndent())
                 .build()

--- a/src/main/kotlin/com/learnspigot/bot/help/ThreadListener.kt
+++ b/src/main/kotlin/com/learnspigot/bot/help/ThreadListener.kt
@@ -36,25 +36,14 @@ class ThreadListener : ListenerAdapter() {
             embed()
                 .setTitle("Thank you for creating a post!")
                 .setDescription("""
-                    Please allow someone to read through your post and answer it!
-                    
-                    If you fixed your problem, please run ${if (closeId == null) "/close" else "</close:$closeId>"}.
-                """.trimIndent())
+            Please allow someone to read through your post and answer it!
+            ${if (!containsPastebinLink) """
+            We've noticed that you didn't send us any code, if that's voluntary, you can ignore this message!
+            If not, feel free to send us the code with our pastebin: https://paste.learnspigot.com""" else ""}
+            
+            If you fixed your problem, please run ${if (closeId == null) "/close" else "</close:$closeId>"}.
+            """.trimIndent())
                 .build()
         ).queue()
-
-        if (!containsPastebinLink) {
-            threadChannel.sendMessageEmbeds(
-                embed()
-                    .setTitle("No Code Provided!")
-                    .setDescription(
-                        """
-                        We've noticed that you didn't send us any code, if that's voluntary, you can ignore this message!
-                        If not, feel free to send us the code with our pastebin: https://paste.learnspigot.com
-                    """.trimIndent()
-                    )
-                    .build()
-            ).queue()
-        }
     }
 }

--- a/src/main/kotlin/com/learnspigot/bot/help/ThreadListener.kt
+++ b/src/main/kotlin/com/learnspigot/bot/help/ThreadListener.kt
@@ -11,9 +11,7 @@ class ThreadListener : ListenerAdapter() {
         if (event.channelType != ChannelType.GUILD_PUBLIC_THREAD) return
         if (event.channel.asThreadChannel().parentChannel.id != Server.helpChannel.id) return
 
-        val threadChannel = event.channel.asThreadChannel()
-
-        val parentMessage = threadChannel.retrieveParentMessage().complete()
+        val parentMessage = event.channel.asThreadChannel().retrieveParentMessage().complete()
 
         val PASTEBINS = listOf(
             "pastebin.com",
@@ -28,7 +26,7 @@ class ThreadListener : ListenerAdapter() {
             ?.id
         val containsPastebinLink = PASTEBINS.any { parentMessage?.contentRaw?.contains(it, ignoreCase = true) == true }
 
-        threadChannel.sendMessageEmbeds(
+        event.channel.asThreadChannel().sendMessageEmbeds(
             embed()
                 .setTitle("Thank you for creating a post!")
                 .setDescription("""
@@ -40,7 +38,7 @@ class ThreadListener : ListenerAdapter() {
         ).queue()
 
         if (!containsPastebinLink) {
-            threadChannel.sendMessageEmbeds(
+            event.channel.asThreadChannel().sendMessageEmbeds(
                 embed()
                     .setTitle("No Code Provided!")
                     .setDescription(

--- a/src/main/kotlin/com/learnspigot/bot/lecture/LectureRegistry.kt
+++ b/src/main/kotlin/com/learnspigot/bot/lecture/LectureRegistry.kt
@@ -328,6 +328,11 @@ class LectureRegistry {
                     "You'll learn how to create cool-looking single and multi-line holograms and how to make them clickable!"
                 ),
                 Lecture(
+                    "37363462",
+                    "Display Entities (1.19.4+)",
+                    "You'll learn how to create amazing floating text, blocks and items without Texture Packs."
+                ),
+                Lecture(
                     "29869478",
                     "Setting Permissions",
                     "You'll learn the (annoyingly complicated) way of manually applying and removing specific permissions on players."

--- a/src/main/kotlin/com/learnspigot/bot/util/PasteBins.kt
+++ b/src/main/kotlin/com/learnspigot/bot/util/PasteBins.kt
@@ -1,0 +1,9 @@
+package com.learnspigot.bot.util
+
+object PasteBins {
+    val pb = "pastebin.com"
+    val md5 = "paste.md-5.net"
+    val helpch = "paste.helpch.at"
+    val ls = "paste.learnspigot.com"
+    val discord = "```"
+}

--- a/src/main/kotlin/com/learnspigot/bot/verification/VerificationListener.kt
+++ b/src/main/kotlin/com/learnspigot/bot/verification/VerificationListener.kt
@@ -220,7 +220,7 @@ class VerificationListener : ListenerAdapter() {
                 .setTitle("Your profile has been received!")
                 .setDescription("""
                         Please wait a short while as staff verify that you own the course! Once verified, this channel will disappear and you'll be able to talk in the rest of the server.
-                        
+                        Don't re-send the verify if not asked by one of the members of the Staff Team.
                         If you have any concerns, please ask in <#${Environment.get("QUESTIONS_CHANNEL_ID")}""" + ">." + """
  
                         """)

--- a/src/main/kotlin/com/learnspigot/bot/verification/VerificationListener.kt
+++ b/src/main/kotlin/com/learnspigot/bot/verification/VerificationListener.kt
@@ -196,7 +196,7 @@ class VerificationListener : ListenerAdapter() {
 
         var url = e.getValue("url")!!.asString
 
-        if (url.contains("|")) {
+        if (url.contains("|") || url.startsWith("udemy.com/course")) {
             e.reply("Invalid profile link.").setEphemeral(true).queue()
             return
         }


### PR DESCRIPTION
feat(HelpPost): Added a check to see if the first message of a Help Post contains code, if not it warns the user. (I added support for default Pastebin links and Discord’s default system to send formatted code.)
(fix): Added missing lecture about Display Entities