### PR TITLE
(fix) Blocking Course link when verifying

### DIFF
--- a/src/main/kotlin/com/learnspigot/bot/verification/VerificationListener.kt
+++ b/src/main/kotlin/com/learnspigot/bot/verification/VerificationListener.kt
@@ -229,7 +229,7 @@ class VerificationListener : ListenerAdapter() {
         var url = e.getValue("url")!!.asString
         val isPersonalPlan = e.getValue("personal_plan")?.asString?.lowercase() == "yes"
 
-        if (url.contains("|") || url.startsWith("udemy.com/course")) {
+        if (url.contains("|") || url.startsWith("https://www.udemy.com/course")) {
             e.reply("Invalid profile link.").setEphemeral(true).queue()
             return
         }


### PR DESCRIPTION
The error is pretty self-explanatory.
I just fixed an old issue, it should now block users from trying to verify with the course link.